### PR TITLE
Fixing Duplicate DailyIframe instances are not allowed Error 

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/vapi.ts
+++ b/vapi.ts
@@ -1,19 +1,17 @@
-import { Call, CreateAssistantDTO } from "./api";
+import { Call, CreateAssistantDTO } from './api';
 import DailyIframe, {
   DailyCall,
   DailyEventObjectAppMessage,
   DailyEventObjectParticipant,
   DailyEventObjectRemoteParticipantsAudioLevel,
-} from "@daily-co/daily-js";
+} from '@daily-co/daily-js';
 
-import type { ChatCompletionMessageParam } from "openai/resources";
-import EventEmitter from "events";
-import { client } from "./client";
+import type { ChatCompletionMessageParam } from 'openai/resources';
+import EventEmitter from 'events';
+import { client } from './client';
 
 function destroyAudioPlayer(participantId: string) {
-  const player = document.querySelector(
-    `audio[data-participant-id="${participantId}"]`
-  );
+  const player = document.querySelector(`audio[data-participant-id="${participantId}"]`);
   player?.remove();
 }
 async function startPlayer(player: HTMLAudioElement, track: any) {
@@ -25,7 +23,7 @@ async function startPlayer(player: HTMLAudioElement, track: any) {
   }
 }
 async function buildAudioPlayer(track: any, participantId: string) {
-  const player = document.createElement("audio");
+  const player = document.createElement('audio');
   player.dataset.participantId = participantId;
   document.body.appendChild(player);
   await startPlayer(player, track);
@@ -43,56 +41,44 @@ function subscribeToTracks(e: DailyEventObjectParticipant, call: DailyCall) {
 }
 
 export interface AddMessageMessage {
-  type: "add-message";
+  type: 'add-message';
   message: ChatCompletionMessageParam;
 }
 
 type VapiClientToServerMessage = AddMessageMessage;
 
 type VapiEventNames =
-  | "call-end"
-  | "call-start"
-  | "volume-level"
-  | "speech-start"
-  | "speech-end"
-  | "message"
-  | "error";
+  | 'call-end'
+  | 'call-start'
+  | 'volume-level'
+  | 'speech-start'
+  | 'speech-end'
+  | 'message'
+  | 'error';
 
 type VapiEventListeners = {
-  "call-end": () => void;
-  "call-start": () => void;
-  "volume-level": (volume: number) => void;
-  "speech-start": () => void;
-  "speech-end": () => void;
+  'call-end': () => void;
+  'call-start': () => void;
+  'volume-level': (volume: number) => void;
+  'speech-start': () => void;
+  'speech-end': () => void;
   message: (message: any) => void;
   error: (error: any) => void;
 };
 
 class VapiEventEmitter extends EventEmitter {
-  on<E extends VapiEventNames>(
-    event: E,
-    listener: VapiEventListeners[E]
-  ): this {
+  on<E extends VapiEventNames>(event: E, listener: VapiEventListeners[E]): this {
     super.on(event, listener);
     return this;
   }
-  once<E extends VapiEventNames>(
-    event: E,
-    listener: VapiEventListeners[E]
-  ): this {
+  once<E extends VapiEventNames>(event: E, listener: VapiEventListeners[E]): this {
     super.once(event, listener);
     return this;
   }
-  emit<E extends VapiEventNames>(
-    event: E,
-    ...args: Parameters<VapiEventListeners[E]>
-  ): boolean {
+  emit<E extends VapiEventNames>(event: E, ...args: Parameters<VapiEventListeners[E]>): boolean {
     return super.emit(event, ...args);
   }
-  removeListener<E extends VapiEventNames>(
-    event: E,
-    listener: VapiEventListeners[E]
-  ): this {
+  removeListener<E extends VapiEventNames>(event: E, listener: VapiEventListeners[E]): this {
     super.removeListener(event, listener);
     return this;
   }
@@ -110,7 +96,7 @@ export default class Vapi extends VapiEventEmitter {
 
   constructor(apiToken: string, apiBaseUrl?: string) {
     super();
-    client.baseUrl = apiBaseUrl ?? "https://api.vapi.ai";
+    client.baseUrl = apiBaseUrl ?? 'https://api.vapi.ai';
     client.setSecurityData(apiToken);
   }
 
@@ -131,43 +117,46 @@ export default class Vapi extends VapiEventEmitter {
     try {
       const webCall = (
         await client.call.callControllerCreateWebCall({
-          assistant: typeof assistant === "string" ? undefined : assistant,
-          assistantId: typeof assistant === "string" ? assistant : undefined,
+          assistant: typeof assistant === 'string' ? undefined : assistant,
+          assistantId: typeof assistant === 'string' ? assistant : undefined,
         })
       ).data;
 
+      if (this.call) {
+        this.call.destroy();
+      }
       this.call = DailyIframe.createCallObject({
         audioSource: true,
         videoSource: false,
       });
-      this.call.iframe()?.style.setProperty("display", "none");
+      this.call.iframe()?.style.setProperty('display', 'none');
 
-      this.call.on("left-meeting", () => {
-        this.emit("call-end");
+      this.call.on('left-meeting', () => {
+        this.emit('call-end');
         this.cleanup();
       });
 
-      this.call.on("participant-left", (e) => {
+      this.call.on('participant-left', (e) => {
         if (!e) return;
         destroyAudioPlayer(e.participant.session_id);
       });
 
-      this.call.on("error", () => {
+      this.call.on('error', () => {
         // Ignore error
       });
 
-      this.call.on("track-started", async (e) => {
+      this.call.on('track-started', async (e) => {
         if (!e || !e.participant) return;
         if (e.participant?.local) return;
-        if (e.track.kind !== "audio") return;
+        if (e.track.kind !== 'audio') return;
 
         await buildAudioPlayer(e.track, e.participant.session_id);
 
-        if (e?.participant?.user_name !== "Vapi Speaker") return;
-        this.call?.sendAppMessage("playable");
+        if (e?.participant?.user_name !== 'Vapi Speaker') return;
+        this.call?.sendAppMessage('playable');
       });
 
-      this.call.on("participant-joined", (e) => {
+      this.call.on('participant-joined', (e) => {
         if (!e || !this.call) return;
         subscribeToTracks(e, this.call);
       });
@@ -179,16 +168,16 @@ export default class Vapi extends VapiEventEmitter {
 
       this.call.startRemoteParticipantsAudioLevelObserver(100);
 
-      this.call.on("remote-participants-audio-level", (e) => {
+      this.call.on('remote-participants-audio-level', (e) => {
         if (e) this.handleRemoteParticipantsAudioLevel(e);
       });
 
-      this.call.on("app-message", (e) => this.onAppMessage(e));
+      this.call.on('app-message', (e) => this.onAppMessage(e));
 
       this.call.updateInputSettings({
         audio: {
           processor: {
-            type: "noise-cancellation",
+            type: 'noise-cancellation',
           },
         },
       });
@@ -196,7 +185,7 @@ export default class Vapi extends VapiEventEmitter {
       return webCall;
     } catch (e) {
       console.error(e);
-      this.emit("error", e);
+      this.emit('error', e);
       this.cleanup();
       return null;
     }
@@ -205,14 +194,14 @@ export default class Vapi extends VapiEventEmitter {
   private onAppMessage(e?: DailyEventObjectAppMessage) {
     if (!e) return;
     try {
-      if (e.data === "listening") {
-        return this.emit("call-start");
+      if (e.data === 'listening') {
+        return this.emit('call-start');
       } else {
         try {
           const parsedMessage = JSON.parse(e.data);
-          this.emit("message", parsedMessage);
+          this.emit('message', parsedMessage);
         } catch (parseError) {
-          console.log("Error parsing message data: ", parseError);
+          console.log('Error parsing message data: ', parseError);
         }
       }
     } catch (e) {
@@ -220,15 +209,10 @@ export default class Vapi extends VapiEventEmitter {
     }
   }
 
-  private handleRemoteParticipantsAudioLevel(
-    e: DailyEventObjectRemoteParticipantsAudioLevel
-  ) {
-    const speechLevel = Object.values(e.participantsAudioLevel).reduce(
-      (a, b) => a + b,
-      0
-    );
+  private handleRemoteParticipantsAudioLevel(e: DailyEventObjectRemoteParticipantsAudioLevel) {
+    const speechLevel = Object.values(e.participantsAudioLevel).reduce((a, b) => a + b, 0);
 
-    this.emit("volume-level", Math.min(1, speechLevel / 0.15));
+    this.emit('volume-level', Math.min(1, speechLevel / 0.15));
 
     const isSpeaking = speechLevel > 0.01;
 
@@ -238,11 +222,11 @@ export default class Vapi extends VapiEventEmitter {
       clearTimeout(this.speakingTimeout);
       this.speakingTimeout = null;
     } else {
-      this.emit("speech-start");
+      this.emit('speech-start');
     }
 
     this.speakingTimeout = setTimeout(() => {
-      this.emit("speech-end");
+      this.emit('speech-end');
       this.speakingTimeout = null;
     }, 1000);
   }
@@ -260,7 +244,7 @@ export default class Vapi extends VapiEventEmitter {
   public setMuted(mute: boolean) {
     try {
       if (!this.call) {
-        throw new Error("Call object is not available.");
+        throw new Error('Call object is not available.');
       }
       this.call.setLocalAudio(!mute);
     } catch (error) {

--- a/vapi.ts
+++ b/vapi.ts
@@ -123,7 +123,7 @@ export default class Vapi extends VapiEventEmitter {
       ).data;
 
       if (this.call) {
-        this.call.destroy();
+        this.cleanup();
       }
       this.call = DailyIframe.createCallObject({
         audioSource: true,


### PR DESCRIPTION
Fixing Duplicate DailyIframe instances are not allowed Error by destroying the current call if exist before starting a new one based on the Daily Docs https://www.daily.co/blog/how-to-properly-destroy-a-daily-video-call-instance/#destroying-a-daily-video-call-instance and add prettier for code formatting