### PR TITLE
Add video recording logic

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1909,6 +1909,11 @@ export interface OverrideAssistantDTO {
     | 'machine_end_silence'
     | 'machine_end_other';
   /**
+   * This sets whether the user video is recorded. Defaults to false.
+   * @example true
+   */
+  videoRecordingEnabled?: boolean;
+  /**
    * This sets whether the assistant's calls are recorded. Defaults to true.
    * @example true
    */

--- a/vapi.ts
+++ b/vapi.ts
@@ -142,7 +142,7 @@ export default class Vapi extends VapiEventEmitter {
       }
       this.call = DailyIframe.createCallObject({
         audioSource: true,
-        videoSource: false,
+        videoSource: assistantOverrides?.videoRecordingEnabled ?? false,
       });
       this.call.iframe()?.style.setProperty('display', 'none');
 
@@ -284,9 +284,9 @@ export default class Vapi extends VapiEventEmitter {
 
   public say(message: string, endCallAfterSpoken?: boolean) {
     this.send({
-      type:'say', 
+      type: 'say',
       message,
-      endCallAfterSpoken
-    })
+      endCallAfterSpoken,
+    });
   }
 }


### PR DESCRIPTION
Hey @jordancde  - had a chat with Alex and this is where we got to for changes in the web SDK to allow for video recordings. Should be pretty minor.

Including this PR as an example of the following changes.

Main open question is whether or not you guys use the `cloud` or `raw` recording setting in DailyCo


**Changes required in vapi/web**

1) Add conditional option for recording user video

- This could be in the [[constructor](https://github.com/VapiAI/web/blob/e1bb6e745fcc5c9120fb5675f8d5ec39cf7ecc4a/vapi.ts#L108)](https://github.com/VapiAI/web/blob/e1bb6e745fcc5c9120fb5675f8d5ec39cf7ecc4a/vapi.ts#L108) or the [[OverrideAssistantDTO](https://github.com/VapiAI/web/blob/e1bb6e745fcc5c9120fb5675f8d5ec39cf7ecc4a/api.ts#L1860)](https://github.com/VapiAI/web/blob/e1bb6e745fcc5c9120fb5675f8d5ec39cf7ecc4a/api.ts#L1860) object

2) This would then be passed to the Vapi backend in the [[body](https://github.com/VapiAI/web/blob/e1bb6e745fcc5c9120fb5675f8d5ec39cf7ecc4a/api.ts#L3663)](https://github.com/VapiAI/web/blob/e1bb6e745fcc5c9120fb5675f8d5ec39cf7ecc4a/api.ts#L3663) of the request to `/call/web`

3) Pass this flag to the DailyCall to join with the video source enabled

```jsx
this.call = DailyIframe.createCallObject({
    audioSource: true,
    videoSource: [FLAG],
});
```

**Changes required in vapi api**

1) Add a `videoRecordingUrl` to the response when a request is made to the [[Get Call](https://docs.vapi.ai/api-reference/calls/get-call)](https://docs.vapi.ai/api-reference/calls/get-call) endpoint

or

2) Ensure that existing `recordingUrl` returns .mp4 recording from [Daily.co](http://daily.co/)