### PR TITLE
refactor: Update Vapi constructor signature and properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ vapi.start({
         content: "You are an assistant.",
       },
      ],
-   }
+   },
    voice: {
     provider: "11labs",
     voiceId: "burt",

--- a/vapi.ts
+++ b/vapi.ts
@@ -166,7 +166,7 @@ export default class Vapi extends VapiEventEmitter {
       this.call = DailyIframe.createCallObject({
         audioSource: this.dailyCallObject.audioSource ?? true,
         videoSource: isVideoRecordingEnabled,
-        dailyConfig: this.dailyCallConfig || {}
+        dailyConfig: this.dailyCallConfig
       });
       this.call.iframe()?.style.setProperty('display', 'none');
 

--- a/vapi.ts
+++ b/vapi.ts
@@ -5,6 +5,7 @@ import DailyIframe, {
   DailyEventObjectAppMessage,
   DailyEventObjectParticipant,
   DailyEventObjectRemoteParticipantsAudioLevel,
+  DailyFactoryOptions,
 } from '@daily-co/daily-js';
 
 import type { ChatCompletionMessageParam } from 'openai/resources';
@@ -110,12 +111,19 @@ export default class Vapi extends VapiEventEmitter {
   private call: DailyCall | null = null;
   private speakingTimeout: NodeJS.Timeout | null = null;
   private dailyCallConfig: DailyAdvancedConfig = {}
+  private dailyCallObject: DailyFactoryOptions = {}
 
-  constructor(apiToken: string, apiBaseUrl?: string, dailyCallConfig?: Pick<DailyAdvancedConfig, 'avoidEval'>) {
+  constructor(
+    apiToken: string, 
+    apiBaseUrl?: string, 
+    dailyCallConfig?: Pick<DailyAdvancedConfig, 'avoidEval' | 'alwaysIncludeMicInPermissionPrompt'>,
+    dailyCallObject?: Pick<DailyFactoryOptions, 'audioSource'>
+  ) {
     super();
     client.baseUrl = apiBaseUrl ?? 'https://api.vapi.ai';
     client.setSecurityData(apiToken);
     this.dailyCallConfig = dailyCallConfig ?? {}
+    this.dailyCallObject = dailyCallObject ?? {}
   }
 
   private cleanup() {
@@ -156,9 +164,9 @@ export default class Vapi extends VapiEventEmitter {
       const isVideoRecordingEnabled = webCall?.artifactPlan?.videoRecordingEnabled ?? false;
 
       this.call = DailyIframe.createCallObject({
-        audioSource: true,
+        audioSource: this.dailyCallObject.audioSource ?? true,
         videoSource: isVideoRecordingEnabled,
-        dailyConfig: this.dailyCallConfig
+        dailyConfig: this.dailyCallConfig || {}
       });
       this.call.iframe()?.style.setProperty('display', 'none');
 


### PR DESCRIPTION
Allows configuring the Daily call object’s audioSource property for special use cases where microphone input is not needed.

However, please note that this requires user interaction before calling vapi.start to avoid issues related to autoplay restrictions, as explained [here](https://developer.chrome.com/blog/autoplay/).

Example config
```

const vapi = new Vapi('...', undefined, {
  alwaysIncludeMicInPermissionPrompt: false
}, {
  audioSource: false
});
```