### PR TITLE
fix: return Promise from setOutputDeviceAsync()

### DIFF
--- a/__tests__/vapi.test.ts
+++ b/__tests__/vapi.test.ts
@@ -53,4 +53,15 @@ describe("Vapi", () => {
       expect(res).toBe(false);
     });
   });
+
+  describe("setOutputDeviceAsync", () => {
+    it("should return the Promise from setOutputDeviceAsync", async () => {
+      const mockError = new Error("setSinkId failed");
+      mockCall.setOutputDeviceAsync = jest.fn().mockRejectedValue(mockError);
+
+      await expect(
+        vapi.setOutputDeviceAsync({ outputDeviceId: "test-device" })
+      ).rejects.toThrow("setSinkId failed");
+    });
+  });
 });

--- a/vapi.ts
+++ b/vapi.ts
@@ -1020,7 +1020,7 @@ export default class Vapi extends VapiEventEmitter {
   public setOutputDeviceAsync(
     options: Parameters<DailyCall['setOutputDeviceAsync']>[0],
   ) {
-    this.call?.setOutputDeviceAsync(options);
+    return this.call?.setOutputDeviceAsync(options);
   }
 
   public getDailyCallObject(): DailyCall | null {


### PR DESCRIPTION
Fixes #154

`setOutputDeviceAsync()` doesn't return the promise from `this.call?.setOutputDeviceAsync()`, so consumers can't catch errors from Daily.co's `setSinkId()`. Just adds the missing `return`.

## Test plan
- [x] Added test that verifies the promise rejection is propagated
- [x] All existing tests pass
- [x] Build succeeds