### PR TITLE
Expose Daily recording events on Vapi client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vapi-ai/web",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vapi-ai/web",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "MIT",
       "dependencies": {
         "@daily-co/daily-js": "^0.85.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vapi-ai/web",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "",
   "main": "dist/vapi.js",
   "types": "dist/vapi.d.ts",

--- a/vapi.ts
+++ b/vapi.ts
@@ -5,7 +5,11 @@ import DailyIframe, {
   DailyAdvancedConfig,
   DailyFactoryOptions,
   DailyEventObjectAppMessage,
+  DailyEventObjectNoPayload,
   DailyEventObjectParticipant,
+  DailyEventObjectRecordingError,
+  DailyEventObjectRecordingStarted,
+  DailyEventObjectRecordingStopped,
   DailyEventObjectRemoteParticipantsAudioLevel,
   DailyParticipant,
   DailyVideoSendSettings,
@@ -73,7 +77,12 @@ type VapiEventNames =
   | 'daily-participant-updated'
   | 'call-start-progress'
   | 'call-start-success'
-  | 'call-start-failed';
+  | 'call-start-failed'
+  | 'recording-started'
+  | 'recording-stopped'
+  | 'recording-stats'
+  | 'recording-error'
+  | 'recording-upload-completed';
 
 interface CallStartProgressEvent {
   stage: string;
@@ -181,6 +190,11 @@ type VapiEventListeners = {
   'call-start-progress': (event: CallStartProgressEvent) => void;
   'call-start-success': (event: CallStartSuccessEvent) => void;
   'call-start-failed': (event: CallStartFailedEvent) => void;
+  'recording-started': (event: DailyEventObjectRecordingStarted) => void;
+  'recording-stopped': (event: DailyEventObjectRecordingStopped) => void;
+  'recording-stats': (event: DailyEventObjectNoPayload) => void;
+  'recording-error': (event: DailyEventObjectRecordingError) => void;
+  'recording-upload-completed': (event: DailyEventObjectNoPayload) => void;
 };
 
 type StartCallOptions = {
@@ -537,6 +551,26 @@ export default class Vapi extends VapiEventEmitter {
 
       this.call.on('network-connection', (event: any) => {
         this.emit('network-connection', event);
+      });
+
+      this.call.on('recording-started', (event) => {
+        if (event) this.emit('recording-started', event);
+      });
+
+      this.call.on('recording-stopped', (event) => {
+        if (event) this.emit('recording-stopped', event);
+      });
+
+      this.call.on('recording-stats', (event) => {
+        if (event) this.emit('recording-stats', event);
+      });
+
+      this.call.on('recording-error', (event) => {
+        if (event) this.emit('recording-error', event);
+      });
+
+      this.call.on('recording-upload-completed', (event) => {
+        if (event) this.emit('recording-upload-completed', event);
       });
 
       this.call.on('track-started', async (e) => {
@@ -1159,6 +1193,26 @@ export default class Vapi extends VapiEventEmitter {
 
       this.call.on('network-connection', (event: any) => {
         this.emit('network-connection', event);
+      });
+
+      this.call.on('recording-started', (event) => {
+        if (event) this.emit('recording-started', event);
+      });
+
+      this.call.on('recording-stopped', (event) => {
+        if (event) this.emit('recording-stopped', event);
+      });
+
+      this.call.on('recording-stats', (event) => {
+        if (event) this.emit('recording-stats', event);
+      });
+
+      this.call.on('recording-error', (event) => {
+        if (event) this.emit('recording-error', event);
+      });
+
+      this.call.on('recording-upload-completed', (event) => {
+        if (event) this.emit('recording-upload-completed', event);
       });
 
       this.call.on('track-started', async (e) => {


### PR DESCRIPTION
Forwards Daily's full set of recording events through the Vapi event emitter so consumers can react to the recording lifecycle without reaching into the underlying Daily call object:

- recording-started
- recording-stopped
- recording-stats
- recording-error
- recording-upload-completed

Each event is wired up in both `start()` and `reconnect()` and exposed with the corresponding `DailyEventObject*` type for type safety.

Bumps version to 2.5.3 (minor: additive, non-breaking).

Refs: https://docs.daily.co/reference/daily-js/events/recording-events

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/042b59ec-7a36-4e89-9e8a-7d58f85a904e" />