### PR TITLE
fix: dangling audio elements when user ends the call

### DIFF
--- a/vapi.ts
+++ b/vapi.ts
@@ -257,11 +257,22 @@ async function buildAudioPlayer(
   return player;
 }
 
+function teardownAudioPlayer(player: HTMLAudioElement) {
+  player.srcObject = null;                                                                                                                                      
+  player.remove();    
+}
+
 function destroyAudioPlayer(participantId: string) {
-  const player = document.querySelector(
-    `audio[data-participant-id="${participantId}"]`,
-  );
-  player?.remove();
+  const player = document.querySelector<HTMLAudioElement>(`audio[data-participant-id="${participantId}"]`);
+  if (player) {
+    teardownAudioPlayer(player)
+  };
+}
+
+function destroyAllAudioPlayers() {
+  document
+    .querySelectorAll<HTMLAudioElement>('audio[data-participant-id]')
+    .forEach(teardownAudioPlayer);
 }
 
 function subscribeToTracks(
@@ -346,6 +357,7 @@ export default class Vapi extends VapiEventEmitter {
       await this.call.destroy();
       this.call = null;
     }
+    destroyAllAudioPlayers();
     this.speakingTimeout = null;
   }
 
@@ -973,6 +985,7 @@ export default class Vapi extends VapiEventEmitter {
       await this.call.destroy();
       this.call = null;
     }
+    destroyAllAudioPlayers();
     this.speakingTimeout = null;
   }
 


### PR DESCRIPTION
## Summary

I've been experiencing issues in my app where after having many Vapi-powered conversations in a row, the bot goes to silence. I was able to consistently reproduce this on Safari only.

**Root cause:** The SDK creates an `<audio data-participant-id="...">` element per remote participant via `buildAudioPlayer` and only removes it when Daily's `participant-left` event fires (`destroyAudioPlayer`).

When the user ends the call via `vapi.stop()` → `call.destroy()`, Daily tears down the local client before the server delivers `participant-left` for the bot, so `destroyAudioPlayer` never runs for it. The element stays in the DOM with a dead `MediaStream` attached on `srcObject`, and a new one is appended on the next call. Safari degrades audibly once enough accumulate.

## Reproduce steps

1. Start a call with `vapi.start(...)`.
3. End the call from the client side (call `vapi.stop()`). **Do not** let the bot end it.
4. Inspect the DOM: a stranded `<audio data-participant-id="...">` element remains in `<body>` with a dead `MediaStream` on `srcObject`.
5. Repeat the start/stop cycle several times. Each call appends a new dangling audio element.
6. After a handful of cycles (like 3), assistant audio becomes choppy/quieter/cuts out, and teardown produces audible buffer-flush noise. Chrome tolerates the accumulation longer but eventually exhibits the same symptoms.

## Fix

- Add `teardownAudioPlayer(player)` that explicitly nulls `srcObject` (releasing the `MediaStream` reference so the playback graph is freed immediately instead of waiting on GC) and removes the element from the DOM.
- Add `destroyAllAudioPlayers()` that sweeps every `audio[data-participant-id]` element through the same teardown.
- Call the sweep in both `cleanup()` (covers the bot-ends-call path via `left-meeting` → `cleanup`) and `stop()` (covers the user-ends-call path).
- Existing `destroyAudioPlayer(participantId)` now routes through `teardownAudioPlayer` too, so cleanup behavior is identical across all three call sites.

The sweep is idempotent — if `participant-left` already removed an element, the selector finds nothing.