### PR TITLE
feat: type the `error` event payload (replace `any`)

### DIFF
--- a/vapi.ts
+++ b/vapi.ts
@@ -110,13 +110,31 @@ interface CallStartFailedEvent {
   context: Record<string, any>;
 }
 
-interface SerializedError {
+export interface SerializedError {
   message: string;
   name?: string;
   stack?: string;
   code?: string | number;
   cause?: string;
+  // Provider-specific and backend fields (e.g. reason, details, Daily.co's
+  // errorMsg, or a nested `error` object carrying subscriptionLimits) are
+  // preserved here, so consumers can still read them by narrowing.
   [key: string]: any;
+}
+
+/**
+ * Payload for the `error` event. The SDK always emits this envelope shape:
+ * a `type` discriminator, the serialized `error`, and a `timestamp`, plus an
+ * optional `stage`/`duration` depending on where the failure occurred.
+ */
+export interface VapiError {
+  type: string;
+  error: SerializedError;
+  timestamp: string;
+  stage?: string;
+  duration?: number;
+  totalDuration?: number;
+  context?: Record<string, any>;
 }
 
 /**
@@ -187,7 +205,7 @@ type VapiEventListeners = {
   'speech-end': () => void;
   video: (track: MediaStreamTrack) => void;
   message: (message: any) => void;
-  error: (error: any) => void;
+  error: (error: VapiError) => void;
   'camera-error': (error: any) => void;
   'network-quality-change': (event: any) => void;
   'network-connection': (event: any) => void;


### PR DESCRIPTION
Closes #157

## Problem

The `error` listener is typed `(error: any)` in `VapiEventListeners`, so consumers maintain hand-rolled types and only catch contract changes at runtime. The issue asks for official, versioned types for the `error` event payload.

## Change

Every `this.emit('error', ...)` call site in `vapi.ts` emits the same envelope, so this types it from the actual source:

- Export the existing `SerializedError` interface (it keeps its `[key: string]: any` index signature, so provider/backend fields — e.g. a nested `error.error.subscriptionLimits`, Daily.co's `errorMsg` — remain readable by narrowing).
- Add and export a `VapiError` interface: `type`, `error: SerializedError`, `timestamp`, plus optional `stage`, `duration`, `totalDuration`, and `context` (the fields that actually appear across the emit sites).
- Type `error: (error: VapiError) => void`.

This is a **typings-only change** — no runtime behavior changes. It's non-breaking: the envelope is fully captured, and nested/unknown fields stay accessible through `SerializedError`'s index signature.

Scoped to the `error` event as the issue requested. `camera-error` / `local-audio-level-observer-error` emit the same `SerializedError` envelope and could be typed the same way in a follow-up; `message` is a larger union left out of scope.

## Verification

- `npm run build` (`tsc && tsc --declaration`) passes. Because `emit`'s parameter is `Parameters<VapiEventListeners['error']>`, tsc's excess-property check confirms `VapiError` matches **all 10** `emit('error', ...)` sites (it initially failed on `totalDuration`/`context`, which are now included).
- `npm test`: 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)