### PR TITLE
chore: bump @daily-co/daily-js to 0.91.0 (v2.6.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@vapi-ai/web",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vapi-ai/web",
-      "version": "2.5.3",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
-        "@daily-co/daily-js": "^0.85.0",
+        "@daily-co/daily-js": "^0.91.0",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@daily-co/daily-js": {
-      "version": "0.85.0",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.85.0.tgz",
-      "integrity": "sha512-lpl111ZWNTUWDnwYcPuNi9PGJPbLCeCw6LzmEY40nG0hv1jg5JLVW8Rq3Cj/+lOCP6W6h4PXm211ss0FFnxITQ==",
+      "version": "0.91.0",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.91.0.tgz",
+      "integrity": "sha512-f/f1qBQhDSvMgucfBUNfV1CHYRItQuRcESzkY/wcYLgKtBi/X6bnwvTeKcHORVdb82J/jnIS553cR3gfxC8uCg==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -597,7 +597,7 @@
         "events": "^3.1.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=22.14.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vapi-ai/web",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "description": "",
   "main": "dist/vapi.js",
   "types": "dist/vapi.d.ts",
@@ -31,7 +31,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@daily-co/daily-js": "^0.85.0",
+    "@daily-co/daily-js": "^0.91.0",
     "events": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

Bump `@daily-co/daily-js` from `^0.85.0` → `^0.91.0` (Daily's current `latest` stable; there is no 1.x) and release `@vapi-ai/web` **v2.6.0**.

Scope is intentionally **daily-js only** — no blanket `npm update`, no `api.ts` regeneration — to keep this a clean, reviewable dependency bump.

## Why

Move off the older 0.85 line onto the current stable release.

## Testing

- `npm run build` (tsc + declarations) — clean, no type breakages against 0.91.0.
- `npm test` — 6/6 pass.
- **Live call** verified against the local tarball (`npm run generate-local-build` → example app): call connected, assistant audio clear, clean start/end.

## Behavior note (daily-js 0.89)

From 0.89, when the noise-cancellation (Krisp) audio processor fails, the mic **no longer auto-mutes** — it stays live. We use noise-cancellation via `updateInputSettings` (`vapi.ts:1516`) and already handle `audio-processor-error`. This PR **accepts Daily's new default** (no code change). Flag if we should restore the old auto-mute.

## Supersedes

Replaces the stale automated **#159** (`update-deps-v2.6.0`), which only bumped daily-js to 0.89.1 and also pulled in unrelated dep churn + `api.ts` regen. #159 can be closed in favor of this.
