### PR TITLE
fix: harden web SDK npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,44 +4,122 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
+concurrency:
+  group: npm-release
+  cancel-in-progress: false
+
 jobs:
-  release:
+  verify:
+    name: Verify and package release
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      version: ${{ steps.release.outputs.version }}
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: 'package.json'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Extract version from tag
-        id: extract_version
+      - name: Verify a human published the release
+        env:
+          RELEASE_AUTHOR_TYPE: ${{ github.event.release.author.type }}
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-          echo "Extracted version: $VERSION"
+          set -euo pipefail
 
-      - name: Verify version matches package.json
-        run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION=${{ steps.extract_version.outputs.VERSION }}
-          
-          echo "Package.json version: $PACKAGE_VERSION"
-          echo "Tag version: $TAG_VERSION"
-          
-          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
-            echo "❌ Version mismatch! Package.json version ($PACKAGE_VERSION) does not match tag version ($TAG_VERSION)"
-            echo "Please ensure the package.json version matches the release tag before publishing."
+          if [[ "$RELEASE_AUTHOR_TYPE" != "User" || "$GITHUB_ACTOR" == *"[bot]" ]]; then
+            echo "::error::Only a human GitHub user can publish an npm release."
             exit 1
           fi
-          
-          echo "✅ Version verification passed: $PACKAGE_VERSION = $TAG_VERSION"
+
+      - name: Checkout release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: refs/tags/${{ github.event.release.tag_name }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Verify tag and merged release PR
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          package_version="$(node -p "require('./package.json').version")"
+          lock_version="$(node -p "require('./package-lock.json').version")"
+
+          if [[ "$RELEASE_TAG" != "v${package_version}" ]]; then
+            echo "::error::Release tag ${RELEASE_TAG} does not match package version ${package_version}."
+            exit 1
+          fi
+
+          if [[ "$lock_version" != "$package_version" ]]; then
+            echo "::error::package-lock.json version ${lock_version} does not match package.json version ${package_version}."
+            exit 1
+          fi
+
+          tag_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+          if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
+            echo "::error::Release tag ${RELEASE_TAG} must point to a commit on main."
+            exit 1
+          fi
+
+          pull_requests="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/commits/${tag_commit}/pulls"
+          )"
+          release_pr="$(
+            jq -c \
+              '[.[] | select(.merged_at != null and .base.ref == "main")] | sort_by(.merged_at) | last // empty' \
+              <<< "$pull_requests"
+          )"
+
+          if [[ -z "$release_pr" ]]; then
+            echo "::error::Release tag ${RELEASE_TAG} must point to a pull request merged into main."
+            exit 1
+          fi
+
+          pr_number="$(jq -r '.number' <<< "$release_pr")"
+          base_sha="$(jq -r '.base.sha' <<< "$release_pr")"
+          changed_files="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files?per_page=100" \
+              --jq '.[].filename'
+          )"
+
+          if ! grep -qx 'package.json' <<< "$changed_files"; then
+            echo "::error::Merged PR #${pr_number} did not update package.json."
+            exit 1
+          fi
+
+          if ! grep -qx 'package-lock.json' <<< "$changed_files"; then
+            echo "::error::Merged PR #${pr_number} did not update package-lock.json."
+            exit 1
+          fi
+
+          previous_version="$(
+            git show "${base_sha}:package.json" |
+              node -e "let input = ''; process.stdin.on('data', chunk => input += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(input).version));"
+          )"
+
+          if [[ "$previous_version" == "$package_version" ]]; then
+            echo "::error::Merged PR #${pr_number} did not change the package version."
+            exit 1
+          fi
+
+          echo "Verified v${previous_version} -> v${package_version} from merged PR #${pr_number}."
+          echo "version=${package_version}" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: npm ci
@@ -52,18 +130,120 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Publish to npm
+      - name: Pack npm artifact
+        id: package
         run: |
-          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
-            if [[ "${{ steps.extract_version.outputs.VERSION }}" == *"alpha"* ]]; then
-              npm publish --access public --tag alpha
-            elif [[ "${{ steps.extract_version.outputs.VERSION }}" == *"beta"* ]]; then
-              npm publish --access public --tag beta
-            else
-              npm publish --access public --tag next
-            fi
-          else
-            npm publish --access public
-          fi
+          set -euo pipefail
+          tarball="$(npm pack --json | jq -r '.[0].filename')"
+          test -f "$tarball"
+          echo "tarball=${tarball}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload npm artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-package
+          path: ${{ steps.package.outputs.tarball }}
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish to npm
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Download npm artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-package
+          path: .release
+
+      - name: Publish to npm with OIDC
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          tarball="$(find .release -maxdepth 1 -type f -name '*.tgz' -print -quit)"
+          if [[ -z "$tarball" ]]; then
+            echo "::error::The packaged npm artifact was not downloaded."
+            exit 1
+          fi
+
+          dist_tag="latest"
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            if [[ "$VERSION" == *"alpha"* ]]; then
+              dist_tag="alpha"
+            elif [[ "$VERSION" == *"beta"* ]]; then
+              dist_tag="beta"
+            else
+              dist_tag="next"
+            fi
+          fi
+
+          npm publish "$tarball" --access public --tag "$dist_tag"
+
+  notify:
+    name: Notify Slack
+    if: ${{ always() }}
+    needs: [verify, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.PRODUCTION_RELEASE_OBSERVABILITY_SLACK_WEBHOOK }}
+    steps:
+      - name: Send release result
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          VERIFY_RESULT: ${{ needs.verify.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$SLACK_WEBHOOK_URL" ]]; then
+            echo "::error::PRODUCTION_RELEASE_OBSERVABILITY_SLACK_WEBHOOK is not available to this repository."
+            exit 1
+          fi
+
+          version="${VERSION:-${RELEASE_TAG#v}}"
+          status="failed"
+          if [[ "$VERIFY_RESULT" == "success" && "$PUBLISH_RESULT" == "success" ]]; then
+            status="succeeded"
+          fi
+
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          npm_url="https://www.npmjs.com/package/@vapi-ai/web/v/${version}"
+          text="$(cat <<EOF
+          *Web SDK npm release ${status}*
+          *Repo:* \`${GITHUB_REPOSITORY}\`
+          *Version:* \`@vapi-ai/web@${version}\`
+          *Initiated by:* \`${GITHUB_ACTOR}\`
+          *Release:* <${RELEASE_URL}|${RELEASE_TAG}>
+          *npm:* <${npm_url}|View package>
+          *Workflow:* <${run_url}|View run>
+          EOF
+          )"
+
+          payload="$(jq -n --arg text "$text" '{text: $text}')"
+          curl --fail --show-error --silent \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --request POST \
+            --header 'Content-Type: application/json' \
+            --data "$payload" \
+            "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,17 +21,6 @@ jobs:
     outputs:
       version: ${{ steps.release.outputs.version }}
     steps:
-      - name: Verify a human published the release
-        env:
-          RELEASE_AUTHOR_TYPE: ${{ github.event.release.author.type }}
-        run: |
-          set -euo pipefail
-
-          if [[ "$RELEASE_AUTHOR_TYPE" != "User" || "$GITHUB_ACTOR" == *"[bot]" ]]; then
-            echo "::error::Only a human GitHub user can publish an npm release."
-            exit 1
-          fi
-
       - name: Checkout release tag
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/sdk-release-pr-notification.yml
+++ b/.github/workflows/sdk-release-pr-notification.yml
@@ -1,0 +1,86 @@
+name: SDK Release PR Notification
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    name: Notify Slack
+    if: ${{ github.event.action == 'ready_for_review' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.PRODUCTION_RELEASE_OBSERVABILITY_SLACK_WEBHOOK }}
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect package version change
+        id: package
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          previous_version="$(
+            git show "${BASE_SHA}:package.json" |
+              node -e "let input = ''; process.stdin.on('data', chunk => input += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(input).version));"
+          )"
+          version="$(node -p "require('./package.json').version")"
+
+          is_release="false"
+          if [[ "$previous_version" != "$version" ]]; then
+            is_release="true"
+          fi
+
+          {
+            echo "is_release=${is_release}"
+            echo "previous_version=${previous_version}"
+            echo "version=${version}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        if: ${{ steps.package.outputs.is_release == 'true' }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PREVIOUS_VERSION: ${{ steps.package.outputs.previous_version }}
+          VERSION: ${{ steps.package.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$SLACK_WEBHOOK_URL" ]]; then
+            echo "::warning::PRODUCTION_RELEASE_OBSERVABILITY_SLACK_WEBHOOK is not set; skipping Slack notification."
+            exit 0
+          fi
+
+          text="$(cat <<EOF
+          *Web SDK release PR ready for review*
+          *Repo:* \`${GITHUB_REPOSITORY}\`
+          *PR:* <${PR_URL}|#${PR_NUMBER} ${PR_TITLE}>
+          *Author:* \`${PR_AUTHOR}\`
+          *Package:* \`@vapi-ai/web\` (npm)
+          *Version:* \`v${PREVIOUS_VERSION}\` -> \`v${VERSION}\`
+          *Next:* Review and merge the PR, then a human must publish GitHub Release \`v${VERSION}\` to start the npm release.
+          EOF
+          )"
+
+          payload="$(jq -n --arg text "$text" '{text: $text}')"
+          curl --fail --show-error --silent \
+            --connect-timeout 10 \
+            --max-time 30 \
+            --request POST \
+            --header 'Content-Type: application/json' \
+            --data "$payload" \
+            "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Linear ticket

https://linear.app/vapi/issue/PRISM-1194/web-sdk-harden-npm-releases-with-oidc-and-human-approval

Fixes PRISM-1194

## Value

vapi employees can now release the web SDK without a long-lived npm token. Publishing only succeeds for a version-changing PR merged into protected `main`, where one approving review is required and no actors can bypass the rule.

We found the gap after the `v2.5.3` GitHub release failed npm authentication and never reached the registry.

Small edit since first push: the release workflow no longer checks the release author's identity. Human approval is enforced where SDK code changes, at the protected pull request merge.

## Evidence of value

- The existing `v2.5.3` tag passes the new merged-PR and version-change checks.
- The SDK builds, all 6 tests pass, and the npm package packs successfully.
- Workflow, shell, and security linting pass with no findings.
- Release PRs and final publish results now notify the existing production release observability Slack webhook.

## API Changes (including webhooks + events)

- **Is this changing the public API?**

  - [ ] Yes
  - [x] No

- **If yes, is it backward‐compatible?**
  - [ ] Yes
  - [ ] No

Non backward-compatible changes might break customers' agents. Please proceed with care and notify the team.

## Testing plan

Merge through the protected `main` branch, then publish a GitHub Release from a merged version PR. Confirm npm Trusted Publishing succeeds, the expected package version appears on npm, and Slack receives the release result. A failed workflow, missing Slack notification, or an unchanged npm version indicates a regression.
