### PR TITLE
chore: prepare web SDK v2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@vapi-ai/web",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vapi-ai/web",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
-        "@daily-co/daily-js": "^0.91.0",
+        "@daily-co/daily-js": "^0.87.0",
         "events": "^3.3.0"
       },
       "devDependencies": {
@@ -585,9 +585,9 @@
       }
     },
     "node_modules/@daily-co/daily-js": {
-      "version": "0.91.0",
-      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.91.0.tgz",
-      "integrity": "sha512-f/f1qBQhDSvMgucfBUNfV1CHYRItQuRcESzkY/wcYLgKtBi/X6bnwvTeKcHORVdb82J/jnIS553cR3gfxC8uCg==",
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@daily-co/daily-js/-/daily-js-0.87.0.tgz",
+      "integrity": "sha512-hWHdBDvJwDeg8unz+XG9hD7xamuFi5Jmsk89ASATKL4fdTDHplpxi4PG9aaPXzBZYYLTjuxUje1K7B5uUR+gzw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -597,7 +597,7 @@
         "events": "^3.1.0"
       },
       "engines": {
-        "node": ">=22.14.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vapi-ai/web",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "",
   "main": "dist/vapi.js",
   "types": "dist/vapi.d.ts",
@@ -19,19 +19,19 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/VapiAI/web.git"
+    "url": "git+https://github.com/VapiAI/client-sdk-web.git"
   },
   "author": "vapi",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/VapiAI/web/issues"
+    "url": "https://github.com/VapiAI/client-sdk-web/issues"
   },
-  "homepage": "https://github.com/VapiAI/web#readme",
+  "homepage": "https://github.com/VapiAI/client-sdk-web#readme",
   "engines": {
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@daily-co/daily-js": "^0.91.0",
+    "@daily-co/daily-js": "^0.87.0",
     "events": "^3.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
daily-js@0.87.0 is the newest published Daily version whose package metadata supports the Web SDK’s existing Node range:

```
daily-js 0.87.0: node >=10.0.0
daily-js 0.89.0+: node >=22.14.0
```

Using `0.87.0` preserves the current customer installation contract while we confirm with Daily whether the Node 22 requirement is intentional for consumers of its browser SDK.

This is a temporary compatibility bridge.

----------------------

additionally updated package homepage and bugs.url to `client-sdk-web` from `web`